### PR TITLE
Deploy on Azure: Fix migration issue when deploying edX on Azure

### DIFF
--- a/wiki/migrations/0007_auto__add_articlesubscription.py
+++ b/wiki/migrations/0007_auto__add_articlesubscription.py
@@ -198,4 +198,9 @@ class Migration(SchemaMigration):
         }
     }
 
+    # The migration 'django_notify' should be run first
+    depends_on = (
+        ( "django_notify", "0001_initial" ),
+    )
+
     complete_apps = ['wiki']


### PR DESCRIPTION
The migration step 001 of django_notify should be run before the step 007 of wiki.
@singingwolfboy @cpennington Please review.
