### PR TITLE
Enforcing the dependency in migration

### DIFF
--- a/wiki/migrations/0007_auto__add_articlesubscription.py
+++ b/wiki/migrations/0007_auto__add_articlesubscription.py
@@ -198,4 +198,9 @@ class Migration(SchemaMigration):
         }
     }
 
+    # The migration 'django_notify' should be run first
+    depends_on = (
+        ( "django_notify", "0001_initial" ),
+    )
+
     complete_apps = ['wiki']


### PR DESCRIPTION
The migration step `0001_initial` of `django_notify` should be run before the step `0007_auto__add_articlesubscription` of `wiki` runs.
But in current code, as there is no dependency enforced, these two steps may be run in reverse order, which will cause an error in migrating if the migration was started after a `syncdb` operation on a empty database.
