### PR TITLE
fix RemovedInDjango19Warning warnings

### DIFF
--- a/django_notify/models.py
+++ b/django_notify/models.py
@@ -22,6 +22,7 @@ class NotificationType(models.Model):
         return self.key
     
     class Meta:
+        app_label = 'django_notify'
         db_table = settings.DB_TABLE_PREFIX + '_notificationtype'
         verbose_name = _(u'type')
         verbose_name_plural = _(u'types')
@@ -36,6 +37,7 @@ class Settings(models.Model):
         return _(u"Settings for %s") % self.user.username
     
     class Meta:
+        app_label = 'django_notify'
         db_table = settings.DB_TABLE_PREFIX + '_settings'
         verbose_name = _(u'settings')
         verbose_name_plural = _(u'settings')
@@ -53,6 +55,7 @@ class Subscription(models.Model):
         return _("Subscription for: %s") % str(self.settings.user.username)
 
     class Meta:
+        app_label = 'django_notify'
         db_table = settings.DB_TABLE_PREFIX + '_subscription'
         verbose_name = _(u'subscription')
         verbose_name_plural = _(u'subscriptions')
@@ -98,6 +101,7 @@ class Notification(models.Model):
         return "%s: %s" % (str(self.subscription.settings.user), self.message)
 
     class Meta:
+        app_label = 'django_notify'
         db_table = settings.DB_TABLE_PREFIX + '_notification'
         verbose_name = _(u'notification')
         verbose_name_plural = _(u'notifications')

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ package_data = dict(
 
 setup(
     name = "django-wiki",
-    version = "0.0.2",
+    version = "0.0.3",
     author = "Benjamin Bach",
     author_email = "benjamin@overtag.dk",
     description = ("A wiki system written for the Django framework."),

--- a/wiki/admin.py
+++ b/wiki/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from django.contrib.contenttypes.generic import GenericTabularInline
+from django.contrib.contenttypes.admin import GenericTabularInline
 from django.utils.translation import ugettext_lazy as _
 from mptt.admin import MPTTModelAdmin
 

--- a/wiki/core/plugins/loader.py
+++ b/wiki/core/plugins/loader.py
@@ -6,7 +6,7 @@ https://github.com/ojii/django-load.
 Thanks for the technique!
 """
 from django.conf import settings
-from django.utils.importlib import import_module
+from importlib import import_module
 
 def get_module(app, modname, verbose, failfast):
     """

--- a/wiki/core/plugins/registry.py
+++ b/wiki/core/plugins/registry.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from django.utils.importlib import import_module
+from importlib import import_module
 
 _cache = {}
 _settings_forms = []

--- a/wiki/editors/markitup.py
+++ b/wiki/editors/markitup.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.forms.util import flatatt
+from django.forms.utils import flatatt
 from django.utils.encoding import force_unicode
 from django.utils.html import conditional_escape
 from django.utils.safestring import mark_safe

--- a/wiki/forms.py
+++ b/wiki/forms.py
@@ -2,7 +2,7 @@
 from django import forms
 from django.utils.translation import ugettext_lazy as _
 from django.utils.safestring import mark_safe
-from django.forms.util import flatatt
+from django.forms.utils import flatatt
 from django.utils.encoding import force_unicode
 from django.utils.html import escape, conditional_escape, strip_tags
 

--- a/wiki/management/commands/wikiviz.py
+++ b/wiki/management/commands/wikiviz.py
@@ -74,7 +74,7 @@ from django.db.models.fields.related import \
 try:
     from django.db.models.fields.generic import GenericRelation
 except ImportError:
-    from django.contrib.contenttypes.generic import GenericRelation
+    from django.contrib.contenttypes.fields import GenericRelation
 
 def parse_file_or_list(arg):
     if not arg:

--- a/wiki/models/article.py
+++ b/wiki/models/article.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from django.contrib.contenttypes.models import ContentType
-from django.contrib.contenttypes import generic
+from django.contrib.contenttypes import fields
 from django.contrib.auth.models import User, Group
 from django.db import models
 from django.utils.safestring import mark_safe
@@ -197,7 +197,7 @@ class ArticleForObject(models.Model):
                                        verbose_name=_('content type'),
                                        related_name="content_type_set_for_%(class)s")
     object_id      = models.PositiveIntegerField(_('object ID'))
-    content_object = generic.GenericForeignKey(ct_field="content_type", fk_field="object_id")
+    content_object = fields.GenericForeignKey(ct_field="content_type", fk_field="object_id")
     
     is_mptt = models.BooleanField(default=False, editable=False)
     

--- a/wiki/models/urlpath.py
+++ b/wiki/models/urlpath.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
 
-from django.contrib.contenttypes import generic
+from django.contrib.contenttypes import fields
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.sites.models import Site
 from django.core.exceptions import ValidationError
@@ -33,7 +33,7 @@ class URLPath(MPTTModel):
     objects = managers.URLPathManager()
     _default_manager = objects
     
-    articles = generic.GenericRelation(ArticleForObject)
+    articles = fields.GenericRelation(ArticleForObject)
     
     # Do NOT modify this field - it is updated with signals whenever ArticleForObject is changed.
     article = models.ForeignKey(Article, on_delete=models.CASCADE, editable=False,


### PR DESCRIPTION
TNL-3450

All the warnings are gone except one IPAddressField warning and for that we need to create a new migration. As per discussion with Usman, he will update IPAddressField to GenericIPAddressField along with other changes he wants to make. 