### PR TITLE
Remove redundant operations from migration

### DIFF
--- a/wiki/migrations/0002_remove_article_subscription.py
+++ b/wiki/migrations/0002_remove_article_subscription.py
@@ -12,14 +12,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RemoveField(
-            model_name='articlesubscription',
-            name='articleplugin_ptr',
-        ),
-        migrations.RemoveField(
-            model_name='articlesubscription',
-            name='subscription_ptr',
-        ),
         migrations.DeleteModel(
             name='ArticleSubscription',
         ),


### PR DESCRIPTION
These redundant operations cause the migrations to fail on AWS.
