### PR TITLE
Fix a migration that could never have run successfully

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ package_data = dict(
 
 setup(
     name = "django-wiki",
-    version = "0.0.4",
+    version = "0.0.5",
     author = "Benjamin Bach",
     author_email = "benjamin@overtag.dk",
     description = ("A wiki system written for the Django framework."),

--- a/wiki/migrations/0002_remove_article_subscription.py
+++ b/wiki/migrations/0002_remove_article_subscription.py
@@ -12,14 +12,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RemoveField(
-            model_name='articlesubscription',
-            name='articleplugin_ptr',
-        ),
-        migrations.RemoveField(
-            model_name='articlesubscription',
-            name='subscription_ptr',
-        ),
         migrations.DeleteModel(
             name='ArticleSubscription',
         ),


### PR DESCRIPTION
You can't drop the last column in a table.  I don't understand what
Django was thinking in generating this migration. I hope we don't need
the drop-columns for backward migrations.

I reported this as Django bug https://code.djangoproject.com/ticket/25793, which was marked as  a duplicate of: https://code.djangoproject.com/ticket/24424