### PR TITLE
WL-322: Update django wiki to support multi-tenancy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ package_data = dict(
 
 setup(
     name = "django-wiki",
-    version = "0.0.5",
+    version = "0.0.6",
     author = "Benjamin Bach",
     author_email = "benjamin@overtag.dk",
     description = ("A wiki system written for the Django framework."),

--- a/testproject/testproject/settings.py
+++ b/testproject/testproject/settings.py
@@ -69,6 +69,7 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
+    'wiki.middleware.RequestCache',
     # Uncomment the next line for simple clickjacking protection:
     # 'django.middleware.clickjacking.XFrameOptionsMiddleware',
 )

--- a/wiki/__init__.py
+++ b/wiki/__init__.py
@@ -1,0 +1,1 @@
+from middleware import get_current_request

--- a/wiki/middleware.py
+++ b/wiki/middleware.py
@@ -1,0 +1,62 @@
+import threading
+import importlib
+
+from django.conf import settings
+
+if getattr(settings, "WIKI_REQUEST_CACHE_MIDDLEWARE_CLASS", None):
+    class_name = settings.WIKI_REQUEST_CACHE_MIDDLEWARE_CLASS.split(".")[-1]
+    module = ".".join(settings.WIKI_REQUEST_CACHE_MIDDLEWARE_CLASS.split('.')[:-1])
+    RequestCache = getattr(importlib.import_module(module), class_name)
+else:
+    class _RequestCache(threading.local):
+        """
+        A thread-local for storing the per-request cache.
+        """
+        def __init__(self):
+            super(_RequestCache, self).__init__()
+            self.data = {}
+            self.request = None
+
+
+    REQUEST_CACHE = _RequestCache()
+
+
+    class RequestCache(object):
+        @classmethod
+        def get_request_cache(cls, name=None):
+            """
+            This method is deprecated. Please use :func:`request_cache.get_cache`.
+            """
+            if name is None:
+                return REQUEST_CACHE
+            else:
+                return REQUEST_CACHE.data.setdefault(name, {})
+
+        @classmethod
+        def get_current_request(cls):
+            """
+            This method is deprecated. Please use :func:`request_cache.get_request`.
+            """
+            return REQUEST_CACHE.request
+
+        @classmethod
+        def clear_request_cache(cls):
+            """
+            Empty the request cache.
+            """
+            REQUEST_CACHE.data = {}
+            REQUEST_CACHE.request = None
+
+        def process_request(self, request):
+            self.clear_request_cache()
+            REQUEST_CACHE.request = request
+            return None
+
+        def process_response(self, request, response):
+            self.clear_request_cache()
+            return response
+
+
+def get_current_request():
+    """Return the request associated with the current thread."""
+    return RequestCache.get_current_request()


### PR DESCRIPTION
Hi @ziafazal , @asadiqbal08 

Kindly review this PR, it contains changes for [WL-322](https://openedx.atlassian.net/browse/WL-322).

**Description of [WL-322](https://openedx.atlassian.net/browse/WL-322):**
Django sites framework can be used both in single tenant way(Specifying `SITE_ID` in settings) and multi-tenant way(without specifying `SITE_ID` in settings). We are planning to use it in multi-tenant way whereas Course Wiki(Django-wiki) is using it in single tenant way so we have to modify edX Django Wiki so it should not depend on `SITE_ID` setting instead it should get site info from request using `get_current_site(request)`.

cc: @mattdrayer , @symbolist 
