### PR TITLE
WL-322: set WIKI_REQUEST_CACHE_MIDDLEWARE_CLASS to None if settings is not configured

### DIFF
--- a/wiki/middleware.py
+++ b/wiki/middleware.py
@@ -3,9 +3,16 @@ import importlib
 
 from django.conf import settings
 
-if getattr(settings, "WIKI_REQUEST_CACHE_MIDDLEWARE_CLASS", None):
-    class_name = settings.WIKI_REQUEST_CACHE_MIDDLEWARE_CLASS.split(".")[-1]
-    module = ".".join(settings.WIKI_REQUEST_CACHE_MIDDLEWARE_CLASS.split('.')[:-1])
+# Take WIKI_REQUEST_CACHE_MIDDLEWARE_CLASS from django settings, if settings is not configured or of
+# WIKI_REQUEST_CACHE_MIDDLEWARE_CLASS setting is not defined then use custom middleware from django-wiki
+if hasattr(settings, "WIKI_REQUEST_CACHE_MIDDLEWARE_CLASS"):
+    WIKI_REQUEST_CACHE_MIDDLEWARE_CLASS = settings.WIKI_REQUEST_CACHE_MIDDLEWARE_CLASS
+else:
+    WIKI_REQUEST_CACHE_MIDDLEWARE_CLASS = None
+
+if WIKI_REQUEST_CACHE_MIDDLEWARE_CLASS:
+    class_name = WIKI_REQUEST_CACHE_MIDDLEWARE_CLASS.split(".")[-1]
+    module = ".".join(WIKI_REQUEST_CACHE_MIDDLEWARE_CLASS.split('.')[:-1])
     RequestCache = getattr(importlib.import_module(module), class_name)
 else:
     class _RequestCache(threading.local):


### PR DESCRIPTION
Hi @symbolist , @mattdrayer 

Kindly review this PR, it fixes a test failure in edx-platform.

**Details:**
Some tests in edx-platform are run without configuring settings, so in these cases call to `getattr(settings, "WIKI_REQUEST_CACHE_MIDDLEWARE_CLASS", None)` raises `ImproperlyConfigured` error. I have added a try except block to capture and process this exception.
