### PR TITLE
Remove Django deprecation message.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,8 @@ def build_media_pattern(base_folder, file_extension):
 template_patterns = ( build_media_pattern("templates", "html") +
                       build_media_pattern("static", "js") +
                       build_media_pattern("static", "css") +
-                      build_media_pattern("static", "png") + 
-                      build_media_pattern("static", "jpeg") + 
+                      build_media_pattern("static", "png") +
+                      build_media_pattern("static", "jpeg") +
                       build_media_pattern("static", "gif"))
 
 packages = find_packages()

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ package_data = dict(
 
 setup(
     name = "django-wiki",
-    version = "0.0.6",
+    version = "0.0.8",
     author = "Benjamin Bach",
     author_email = "benjamin@overtag.dk",
     description = ("A wiki system written for the Django framework."),

--- a/wiki/migrations/0003_ip_address_conv.py
+++ b/wiki/migrations/0003_ip_address_conv.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wiki', '0002_remove_article_subscription'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='articlerevision',
+            name='ip_address',
+            field=models.GenericIPAddressField(verbose_name='IP address', null=True, editable=False, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='attachmentrevision',
+            name='ip_address',
+            field=models.GenericIPAddressField(verbose_name='IP address', null=True, editable=False, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='revisionpluginrevision',
+            name='ip_address',
+            field=models.GenericIPAddressField(verbose_name='IP address', null=True, editable=False, blank=True),
+        ),
+    ]

--- a/wiki/models/article.py
+++ b/wiki/models/article.py
@@ -2,6 +2,7 @@
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes import fields
 from django.contrib.auth.models import User, Group
+from django.db.models.fields import GenericIPAddressField
 from django.db import models
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
@@ -217,7 +218,12 @@ class BaseRevisionMixin(models.Model):
     user_message = models.TextField(blank=True,)
     automatic_log = models.TextField(blank=True, editable=False,)
     
-    ip_address  = models.IPAddressField(_('IP address'), blank=True, null=True, editable=False)
+    ip_address  = models.GenericIPAddressField(
+        _('IP address'),
+        blank=True,
+        null=True,
+        editable=False
+    )
     user        = models.ForeignKey(User, verbose_name=_('user'),
                                     blank=True, null=True)    
     


### PR DESCRIPTION
Change from deprecated IPAddressField model field to the new GenericIPAddressField model field.
Bump the version number to 0.0.8.
Add migration file for the field conversion.