### PR TITLE
Increase slug max size

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ package_data = dict(
 
 setup(
     name = "django-wiki",
-    version = "0.0.8",
+    version = "0.0.9",
     author = "Benjamin Bach",
     author_email = "benjamin@overtag.dk",
     description = ("A wiki system written for the Django framework."),

--- a/wiki/forms.py
+++ b/wiki/forms.py
@@ -203,7 +203,8 @@ class CreateForm(forms.Form):
         self.urlpath_parent = urlpath_parent
     
     title = forms.CharField(label=_(u'Title'),)
-    slug = forms.SlugField(label=_(u'Slug'), help_text=_(u"This will be the address where your article can be found. Use only alphanumeric characters and - or _. Note that you cannot change the slug after creating the article."),)
+    slug = forms.SlugField(label=_(u'Slug'), help_text=_(u"This will be the address where your article can be found. Use only alphanumeric characters and - or _. Note that you cannot change the slug after creating the article."),
+                           max_length=models.URLPath.SLUG_MAX_LENGTH)
     content = forms.CharField(label=_(u'Contents'),
                               required=False, widget=getEditor().get_widget()) #@UndefinedVariable
     

--- a/wiki/migrations/0004_increase_slug_size.py
+++ b/wiki/migrations/0004_increase_slug_size.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wiki', '0003_ip_address_conv'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='urlpath',
+            name='slug',
+            field=models.SlugField(max_length=255, null=True, verbose_name='slug', blank=True),
+        ),
+    ]

--- a/wiki/models/urlpath.py
+++ b/wiki/models/urlpath.py
@@ -41,7 +41,9 @@ class URLPath(MPTTModel):
     article = models.ForeignKey(Article, on_delete=models.CASCADE, editable=False,
                                 verbose_name=_(u'Cache lookup value for articles'))
     
-    SLUG_MAX_LENGTH = 50
+    # The slug is constructed from course key and will in practice be much shorter then 255 characters
+    # since course keys are capped at 65 characters in the Studio (https://openedx.atlassian.net/browse/TNL-889).
+    SLUG_MAX_LENGTH = 255
     
     slug = models.SlugField(verbose_name=_(u'slug'), null=True, blank=True,
                             max_length=SLUG_MAX_LENGTH)

--- a/wiki/models/urlpath.py
+++ b/wiki/models/urlpath.py
@@ -41,7 +41,10 @@ class URLPath(MPTTModel):
     article = models.ForeignKey(Article, on_delete=models.CASCADE, editable=False,
                                 verbose_name=_(u'Cache lookup value for articles'))
     
-    slug = models.SlugField(verbose_name=_(u'slug'), null=True, blank=True)
+    SLUG_MAX_LENGTH = 50
+    
+    slug = models.SlugField(verbose_name=_(u'slug'), null=True, blank=True,
+                            max_length=SLUG_MAX_LENGTH)
     site = models.ForeignKey(Site)
     parent = TreeForeignKey('self', null=True, blank=True, related_name='children')    
     


### PR DESCRIPTION
In edx-platform, default course wiki article's slug is automatically set to `"{org}.{number}.{run}"`, which can be more than 50 characters long.

The wiki breaks if the automatically assigned slug is longer than 50 characters.

We usually use 255 character size for columns that store course_key in edx-platform, so I believe it makes sense to use a limit of 255 for wiki slugs, too.

This PR also bumps the version to 0.0.9. Once the PR gets merged, a new v0.0.9 git tag should be created.

I created https://github.com/edx/edx-platform/pull/12978 for testing. Sandboxes are being built.

**JIRA ticket**: TBD

**Dependencies**: None

**Testing instructions**:

1. Before installing this patch, go to Studio and create a new course with long organization, course number, and course run fields (concatenated together should be longer than 50 characters)
2. Go to the wiki page in the LMS. The wiki will raise a 500 error.
3. Install this patch and run the migration.
4. Restart edxapp, go to the wiki page in the LMS. The wiki will work properly (although the layout will look a bit broken due to the ridiculously long name).

**Reviewers**
- [x] @haikuginger 
- [ ] edX reviewer[s] ?