### PR TITLE
Fixed migration 0005

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ package_data = dict(
 
 setup(
     name = "django-wiki",
-    version="0.0.12",
+    version="0.0.13",
     author = "Benjamin Bach",
     author_email = "benjamin@overtag.dk",
     description = ("A wiki system written for the Django framework."),

--- a/wiki/migrations/0005_remove_attachments_and_images.py
+++ b/wiki/migrations/0005_remove_attachments_and_images.py
@@ -17,10 +17,6 @@ class Migration(migrations.Migration):
             name='current_revision',
         ),
         migrations.RemoveField(
-            model_name='attachment',
-            name='reusableplugin_ptr',
-        ),
-        migrations.RemoveField(
             model_name='attachmentrevision',
             name='attachment',
         ),
@@ -31,10 +27,6 @@ class Migration(migrations.Migration):
         migrations.RemoveField(
             model_name='attachmentrevision',
             name='user',
-        ),
-        migrations.RemoveField(
-            model_name='image',
-            name='revisionplugin_ptr',
         ),
         migrations.RemoveField(
             model_name='imagerevision',


### PR DESCRIPTION
Dropping these columns before the containing tables proves problematic in practice (one leaves an empty table that's hard for sqlite to drop, the other is part of a foreign key constraint that trips up the removal).  They go away anyway when the tables are dropped, and this seems to work in both a local sqlite file and docker devstack's default database.