### PR TITLE
Include plugin models again

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ package_data = dict(
 
 setup(
     name = "django-wiki",
-    version="0.0.13",
+    version="0.0.14",
     author = "Benjamin Bach",
     author_email = "benjamin@overtag.dk",
     description = ("A wiki system written for the Django framework."),

--- a/wiki/models/__init__.py
+++ b/wiki/models/__init__.py
@@ -5,8 +5,9 @@ from django.core.exceptions import ImproperlyConfigured
 from six import string_types, text_type
 
 # TODO: Don't use wildcards
-from article import *
-from urlpath import *
+from .article import *
+from .pluginbase import *
+from .urlpath import *
 from django.utils.functional import lazy
 
 # TODO: Should the below stuff be executed a more logical place?


### PR DESCRIPTION
Removing the plugin model imports from the base migration also made Django lose track of the base plugin models, because they hadn't been imported correctly in the models package.  Hence running `makemigrations` would try to create a new migration to remove these tables.  Upstream already fixed this, replicating the fix here.