### PR TITLE
Fix deprecated safe_mode

### DIFF
--- a/wiki/core/__init__.py
+++ b/wiki/core/__init__.py
@@ -3,7 +3,6 @@ import markdown
 class ArticleMarkdown(markdown.Markdown):
     
     def __init__(self, article, *args, **kwargs):
-        kwargs['safe_mode'] = "remove"
         markdown.Markdown.__init__(self, *args, **kwargs)
         self.article = article
 


### PR DESCRIPTION
Django-Wiki removes characters like `:` or `@` in the URL because `safe_mode` is set to `replace`. I have updated it to remove it because in edX we mostly support these in the URL patterns. 

Docs: https://pythonhosted.org/Markdown/release-2.6.html#safe_mode-deprecated



[EDUCATOR-1655](https://openedx.atlassian.net/browse/EDUCATOR-1655)