### PR TITLE
PLAT-1945 Fix deprecated Markdown extension initialization

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ package_data = dict(
 
 setup(
     name = "django-wiki",
-    version="0.0.16",
+    version="0.0.17",
     author = "Benjamin Bach",
     author_email = "benjamin@overtag.dk",
     description = ("A wiki system written for the Django framework."),

--- a/wiki/plugins/links/mdx/djangowikilinks.py
+++ b/wiki/plugins/links/mdx/djangowikilinks.py
@@ -30,20 +30,19 @@ try:
 except ImportError:
     from markdown import etree #@UnresolvedImport @Reimport
 
+
 class WikiPathExtension(markdown.Extension):
-    def __init__(self, configs):
+    def __init__(self, **kwargs):
         # set extension defaults
         self.config = {
-                        'base_url' : ['/', 'String to append to beginning of URL.'],
-                        'html_class' : ['wikipath', 'CSS hook. Leave blank for none.'],
-                        'live_lookups' : [True, 'If the plugin should try and match links to real articles'],
-                        'default_level' : [2, 'The level that most articles are created at. Relative links will tend to start at that level.']
+            'base_url': ['/', 'String to append to beginning of URL.'],
+            'html_class': ['wikipath', 'CSS hook. Leave blank for none.'],
+            'live_lookups': [True, 'If the plugin should try and match links to real articles'],
+            'default_level': [2, 'The level that most articles are created at. Relative links will tend to start at that level.']
         }
         
         # Override defaults with user settings
-        for key, value in configs :
-            # self.config[key][0] = value
-            self.setConfig(key, value)
+        super(WikiPathExtension, self).__init__(**kwargs)
         
     def extendMarkdown(self, md, md_globals):
         self.md = md
@@ -53,6 +52,7 @@ class WikiPathExtension(markdown.Extension):
         wikiPathPattern = WikiPath(WIKI_RE, self.config, markdown_instance=md)
         wikiPathPattern.md = md
         md.inlinePatterns.add('djangowikipath', wikiPathPattern, "<reference")
+
 
 class WikiPath(markdown.inlinepatterns.Pattern):
     def __init__(self, pattern, config, **kwargs):
@@ -130,8 +130,10 @@ class WikiPath(markdown.inlinepatterns.Pattern):
                 html_class = self.md.Meta['wiki_html_class'][0]
         return base_url, html_class
 
-def makeExtension(configs=None) :
-    return WikiPathExtension(configs=configs)
+
+def makeExtension(**kwargs):
+    return WikiPathExtension(**kwargs)
+
 
 if __name__ == "__main__":
     import doctest

--- a/wiki/plugins/links/mdx/urlize.py
+++ b/wiki/plugins/links/mdx/urlize.py
@@ -54,6 +54,7 @@ URLIZE_RE = (
     r'(?:/?|[/?]\S+))'
 )
 
+
 class UrlizePattern(markdown.inlinepatterns.Pattern):
 
     def __init__(self, pattern, markdown_instance=None):
@@ -87,6 +88,7 @@ class UrlizePattern(markdown.inlinepatterns.Pattern):
         el.extend([icon, span_text])
         return el
 
+
 class UrlizeExtension(markdown.Extension):
     """ Urlize Extension for Python-Markdown. """
 
@@ -94,10 +96,10 @@ class UrlizeExtension(markdown.Extension):
         """ Replace autolink with UrlizePattern """
         md.inlinePatterns['autolink'] = UrlizePattern(URLIZE_RE, md)
 
-def makeExtension(configs=None):
-    if configs is None:
-        configs = {}
-    return UrlizeExtension(configs=configs)
+
+def makeExtension(**kwargs):
+    return UrlizeExtension(**kwargs)
+
 
 if __name__ == "__main__":
     import doctest

--- a/wiki/plugins/links/wiki_plugin.py
+++ b/wiki/plugins/links/wiki_plugin.py
@@ -10,6 +10,7 @@ from wiki.plugins.links.mdx.urlize import makeExtension
 from wiki.plugins.links.mdx.djangowikilinks import WikiPathExtension
 from django.core.urlresolvers import reverse_lazy
 
+
 class LinkPlugin(BasePlugin):
     
     slug = 'links'
@@ -29,10 +30,10 @@ class LinkPlugin(BasePlugin):
         ('default_level', settings.LINK_DEFAULT_LEVEL ),
         ]
     
-    markdown_extensions = [makeExtension(), WikiPathExtension(wikipath_config)]
+    markdown_extensions = [makeExtension(), WikiPathExtension(**dict(wikipath_config))]
     
     def __init__(self):
         pass
-    
-registry.register(LinkPlugin)
 
+
+registry.register(LinkPlugin)


### PR DESCRIPTION
We've been using a mechanism for initializing Markdown extensions that was deprecated in version 2.6 of the package; see the [release notes](https://python-markdown.github.io/change_log/release-2.6/#the-configs-keyword-is-deprecated) for details.  Now that we show deprecation warnings in edx-platform on management command execution, this was one of the few that was consistently being output for almost every command.