### PR TITLE
Retire User from RevisionPluginRevision

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,3 @@ virtualenv
 *.swp
 
 .idea/
-
-.idea/vcs.xml

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,15 @@
 import os
 from setuptools import setup, find_packages
 
-# Utility function to read the README file.
-# Used for the long_description.  It's nice, because now 1) we have a top level
-# README file and 2) it's easier to type in the README file than to put a raw
-# string in below ...
+
 def read(fname):
+    """
+    Utility function to read the README file.
+    Used for the long_description.  It's nice, because now 1) we have a top level
+    README file and 2) it's easier to type in the README file than to put a raw
+    string in below ...
+
+    """
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 

--- a/wiki/models/pluginbase.py
+++ b/wiki/models/pluginbase.py
@@ -198,8 +198,7 @@ class RevisionPluginRevision(BaseRevisionMixin, models.Model):
             not self.previous_revision and 
             self.plugin and
             self.plugin.current_revision and 
-            self.plugin.current_revision != self):
-            
+                self.plugin.current_revision != self):
             self.previous_revision = self.plugin.current_revision
 
         if not self.revision_number:
@@ -216,6 +215,15 @@ class RevisionPluginRevision(BaseRevisionMixin, models.Model):
             self.plugin.current_revision = self
             self.plugin.save()
 
+    @classmethod
+    def retire_user(cls, user):
+        """
+        Updates a user record as a part of GDPR Phase II
+        :param user (obj)
+        :return: bool
+        """
+        return cls.objects.filter(user=user).update(ip_address='') > 0
+
     class Meta:
         get_latest_by = 'revision_number'
         ordering = ('-created',)
@@ -228,6 +236,7 @@ class RevisionPluginRevision(BaseRevisionMixin, models.Model):
 # And the plane becomes a metaphor for my life.
 # It's my art, when I disguise my body in the shape of a plane.
 # (Shellac, 1993)
+
 
 def update_simple_plugins(instance, *args, **kwargs):
     """Every time a new article revision is created, we update all active 


### PR DESCRIPTION
## [EDUCATOR-2702](https://openedx.atlassian.net/browse/EDUCATOR-2702)

### Description
Add a class method to blank out `ip_address` field for user on `RevisionPluginRevision` model class. (will piggyback onto 0.0.18 release from https://github.com/edx/django-wiki/pull/34)

### Testing
This lib appears to lack unit tests. This will be unit tested on the LMS side and manually before launch.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @schenedx  

FYI: @edx/educator-neem 

### Post-review
- [ ] Rebase and squash commits
