### PR TITLE
fixes edx-platform translation issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ package_data = dict(
 
 setup(
     name = "django-wiki",
-    version="0.0.18",
+    version="0.0.19",
     author="Benjamin Bach",
     author_email="benjamin@overtag.dk",
     description=("A wiki system written for the Django framework."),

--- a/wiki/plugins/attachments/templates/wiki/plugins/attachments/delete.html
+++ b/wiki/plugins/attachments/templates/wiki/plugins/attachments/delete.html
@@ -8,7 +8,7 @@
 {% if attachment.article == article %}
 <h2>{% trans "Delete" %} "{{ attachment.current_revision.get_filename }}"?</h2>
   <p class="lead">
-    {% blocktrans with attachment.original_filename as filename %}
+    {% blocktrans with attachment.original_filename as filename trimmed %}
     The file may be referenced on other articles. Deleting it means that they will loose their references to this file. The following articles reference this file:
     {% endblocktrans %}
   </p>
@@ -35,7 +35,7 @@
 {% else %}
   <h2>{% trans "Remove" %} "{{ attachment.current_revision.get_filename }}"?</h2>
   <p class="lead">
-    {% blocktrans with attachment.original_filename as filename %}
+    {% blocktrans with attachment.original_filename as filename trimmed %}
     You can remove a reference to a file, but it will retain its references on other articles.
     {% endblocktrans %}
   </p>

--- a/wiki/plugins/attachments/templates/wiki/plugins/attachments/replace.html
+++ b/wiki/plugins/attachments/templates/wiki/plugins/attachments/replace.html
@@ -8,7 +8,7 @@
 <h2>{% trans "Replace" %} "{{ attachment.current_revision.get_filename }}"</h2>
 {% if attachment.articles.count > 1 %}
 <p class="lead">
-  {% blocktrans with attachment.original_filename as filename %}
+  {% blocktrans with attachment.original_filename as filename trimmed %}
   Replacing an attachment means adding a new file that will be used in its place. All references to the file will be replaced by the one you upload and the file will be downloaded as <strong>{{ filename }}</strong>. Please note that this attachment is in use on other articles, you may distort contents. However, do not hestitate to take advantage of this and make replacements for the listed articles where necessary. This way of working is more efficient....
   {% endblocktrans %}
 </p>
@@ -19,7 +19,7 @@
 <hr />
 {% else %}
 <p class="lead">
-  {% blocktrans with attachment.original_filename as filename %}
+  {% blocktrans with attachment.original_filename as filename trimmed %}
   Replacing an attachment means adding a new file that will be used in its place. All references to the file will be replaced by the one you upload and the file will be downloaded as <strong>{{ filename }}</strong>.
   {% endblocktrans %}
 </p>

--- a/wiki/templates/wiki/dir.html
+++ b/wiki/templates/wiki/dir.html
@@ -37,11 +37,11 @@
 <p>
   {% with paginator.object_list.count as cnt %}
     {% if filter_query %}
-      {% blocktrans with cnt|pluralize:_("article,articles") as articles_plur and cnt|pluralize:_("matches,match") as match_plur %}
+      {% blocktrans with cnt|pluralize:_("article,articles") as articles_plur and cnt|pluralize:_("matches,match") as match_plur trimmed %}
         {{ cnt }} {{ articles_plur }} in this level {{ match_plur }} your search.
       {% endblocktrans %}
     {% else %}
-      {% blocktrans with cnt|pluralize:_("article,articles") as articles_plur and cnt|pluralize:_("is,are") as articles_plur_verb %}
+      {% blocktrans with cnt|pluralize:_("article,articles") as articles_plur and cnt|pluralize:_("is,are") as articles_plur_verb trimmed %}
         There {{ articles_plur_verb }} {{ cnt }} {{ articles_plur }} in this level.
       {% endblocktrans %}
     {% endif %}

--- a/wiki/templates/wiki/includes/anonymous_blocked.html
+++ b/wiki/templates/wiki/includes/anonymous_blocked.html
@@ -3,7 +3,7 @@
 {% url 'wiki:signup' as signup_url %}
 {% url 'wiki:login' as login_url %}
 {% if login_url and signup_url %}
-  {% blocktrans %}
+  {% blocktrans trimmed %}
   You need to <a href="{{ login_url }}">log in</a> or <a href="{{ signup_url }}">sign up</a> to use this function.
   {% endblocktrans %}
 {% else %}


### PR DESCRIPTION
Added trimmed to blocktrans to remove the unnecessary newline or endline characters being added to translation strings.
Because of the following issue we face when generate translations in edx-platform.
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/bin/i18n_tool", line 11, in <module>
    sys.exit(main())
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/i18n/main.py", line 60, in main
    return module.main()
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/i18n/__init__.py", line 51, in __call__
    return self.run(args)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/i18n/generate.py", line 176, in run
    merge_files(configuration, locale, fail_if_missing=args.strict)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/i18n/generate.py", line 80, in merge_files
    merge(configuration, locale, target, sources, fail_if_missing)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/i18n/generate.py", line 59, in merge
    duplicate_entries = clean_pofile(merged_filename)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/i18n/generate.py", line 130, in clean_pofile
    ).encode('utf-8')
ValueError: 
  You need to <a href="%(login_url)s">log in</a> or <a href="%(signup_url)s">sign up</a> to use this function.
   starts or ends with a new line character, which is not allowed. Please fix before continuing. Source string is found in [(u'lms/templates/wiki/includes/anonymous_blocked.html', None), (u'wiki/templates/wiki/includes/anonymous_blocked.html', None)]

