### PR TITLE
Fix some Django20 deprecation warnings.

### DIFF
--- a/django_notify/urls.py
+++ b/django_notify/urls.py
@@ -13,8 +13,8 @@ urlpatterns = [
     url('^goto/$', views.goto, name='goto_base', kwargs={}),
 ]
 
-def get_pattern(app_name="notify", namespace="notify"):
+def get_pattern(app_name="notify"):
     """Every url resolution takes place as "notify:view_name".
        https://docs.djangoproject.com/en/dev/topics/http/urls/#topics-http-reversing-url-namespaces
     """
-    return urlpatterns, app_name, namespace
+    return urlpatterns, app_name

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ package_data = dict(
 
 setup(
     name = "django-wiki",
-    version="0.0.23",
+    version="0.0.24",
     author="Benjamin Bach",
     author_email="benjamin@overtag.dk",
     description=("A wiki system written for the Django framework."),

--- a/wiki/templatetags/wiki_tags.py
+++ b/wiki/templatetags/wiki_tags.py
@@ -16,13 +16,13 @@ register = template.Library()
 # called more than once per page in multiple template blocks.
 _cache = {}
 
-@register.assignment_tag(takes_context=True)
+@register.simple_tag(takes_context=True)
 def article_for_object(context, obj):
     if not isinstance(obj, Model):
         raise TypeError("A Wiki article can only be associated to a Django Model instance, not %s" % type(obj))
-    
+
     content_type = ContentType.objects.get_for_model(obj)
-    
+
     # TODO: This is disabled for now, as it should only fire once per request
     # Maybe store cache in the request object?
     if True or not obj in list(_cache.keys()):
@@ -35,7 +35,7 @@ def article_for_object(context, obj):
 
 @register.inclusion_tag('wiki/includes/render.html')
 def wiki_render(article, preview_content=None):
-    
+
     if preview_content:
         content = article.render(preview_content=preview_content)
     else:
@@ -50,10 +50,10 @@ def wiki_render(article, preview_content=None):
 
 @register.inclusion_tag('wiki/includes/form.html', takes_context=True)
 def wiki_form(context, form_obj):
-    
+
     if not isinstance(form_obj, BaseForm):
         raise TypeError("Error including form, it's not a form, it's a %s" % type(form_obj))
-    
+
     return {
         'form': form_obj,
     }

--- a/wiki/urls.py
+++ b/wiki/urls.py
@@ -21,13 +21,13 @@ if settings.ACCOUNT_HANDLING:
     ]
 
 urlpatterns += [
-    # This one doesn't work because it don't know where to redirect after...   
+    # This one doesn't work because it don't know where to redirect after...
     url(r'^_revision/change/(?P<article_id>\d+)/(?P<revision_id>\d+)/$', article.change_revision,
         name='change_revision'),
     url(r'^_revision/preview/(?P<article_id>\d+)/$', article.Preview.as_view(), name='preview_revision'),
     url(r'^_revision/merge/(?P<article_id>\d+)/(?P<revision_id>\d+)/preview/$', article.merge,
         name='merge_revision_preview', kwargs={'preview': True}),
-    
+
     # Paths decided by article_ids
     url(r'^(?P<article_id>\d+)/$', article.ArticleView.as_view(), name='get'),
     url(r'^(?P<article_id>\d+)/delete/$', article.Delete.as_view(), name='delete'),
@@ -69,10 +69,10 @@ urlpatterns += [
     url(r'^(?P<path>.+/|)$', article.ArticleView.as_view(), name='get'),
 ]
 
-def get_pattern(app_name="wiki", namespace="wiki"):
+def get_pattern(app_name="wiki"):
     """Every url resolution takes place as "wiki:view_name".
        You should not attempt to have multiple deployments of the wiki in a
        single Django project.
        https://docs.djangoproject.com/en/dev/topics/http/urls/#topics-http-reversing-url-namespaces
     """
-    return urlpatterns, app_name, namespace
+    return urlpatterns, app_name


### PR DESCRIPTION
Fixes the following Django 2.0 deprecation warnings:

```
  /edx/app/edxapp/edx-platform/lms/urls.py:191: RemovedInDjango20Warning: Passing a 3-tuple to django.conf.urls.include() is deprecated. Pass a 2-tuple containing the list of patterns and app_name, and provide the namespace argument to include() instead.
    url(r'^wiki/', include(wiki_pattern())),
  /edx/app/edxapp/edx-platform/lms/urls.py:192: RemovedInDjango20Warning: Passing a 3-tuple to django.conf.urls.include() is deprecated. Pass a 2-tuple containing the list of patterns and app_name, and provide the namespace argument to include() instead.
    url(r'^notify/', include(notify_pattern())),

openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py::TestDeactivateLogout::test_user_can_deactivate_self
  /edx/app/edxapp/venvs/edxapp/src/django-wiki/wiki/templatetags/wiki_tags.py:16: RemovedInDjango20Warning: assignment_tag() is deprecated. Use simple_tag() instead
    @register.assignment_tag(takes_context=True)
  /edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/template/loaders/filesystem.py:61: RemovedInDjango20Warning: The load_template_sources() method is deprecated. Use get_template() or get_contents() instead.
    RemovedInDjango20Warning,
```