### PR TITLE
BOM-68

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import
 import os
 
 from setuptools import find_packages, setup
-from six.moves import range
 
 
 def read(fname):
@@ -40,7 +39,7 @@ package_data = dict(
 
 setup(
     name = "django-wiki",
-    version="0.0.22",
+    version="0.0.23",
     author="Benjamin Bach",
     author_email="benjamin@overtag.dk",
     description=("A wiki system written for the Django framework."),


### PR DESCRIPTION
https://openedx.atlassian.net/browse/BOM-68.

importing six here is a problem. Because when edx-platform installs from scratch, six won't already exist in the virtual enviroment and the running of setup.py will fail. 