### PR TITLE
[BD-6] Make it compatible with Django 2.2

### DIFF
--- a/django_notify/urls.py
+++ b/django_notify/urls.py
@@ -13,6 +13,8 @@ urlpatterns = [
     url('^goto/$', views.goto, name='goto_base', kwargs={}),
 ]
 
+app_name = 'notify'
+
 def get_pattern(app_name="notify"):
     """Every url resolution takes place as "notify:view_name".
        https://docs.djangoproject.com/en/dev/topics/http/urls/#topics-http-reversing-url-namespaces

--- a/testproject/testproject/settings.py
+++ b/testproject/testproject/settings.py
@@ -52,7 +52,7 @@ STATIC_URL = '/static/'
 
 SECRET_KEY = 'b^fv_)t39h%9p40)fnkfblo##jkr!$0)lkp6bpy!fi*f$4*92!'
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',

--- a/testproject/testproject/urls.py
+++ b/testproject/testproject/urls.py
@@ -9,7 +9,7 @@ from django.contrib import admin
 admin.autodiscover()
 
 urlpatterns = [
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', admin.site.urls),
 ]
 
 if settings.DEBUG:
@@ -18,11 +18,11 @@ if settings.DEBUG:
         url(r'^media/(?P<path>.*)$', static_serve, {'document_root': settings.MEDIA_ROOT}),
     ]
 
-    
+
 from wiki.urls import get_pattern as get_wiki_pattern
 from django_notify.urls import get_pattern as get_notify_pattern
 
 urlpatterns += [
-    url(r'^notify/', get_notify_pattern()),
-    url(r'', get_wiki_pattern()),
+    url(r'^notify/', include('django_notify.urls', namespace='notify')),
+    url(r'', include('wiki.urls', namespace='wiki')),
 ]

--- a/wiki/editors/markitup.py
+++ b/wiki/editors/markitup.py
@@ -36,7 +36,7 @@ class MarkItUpWidget(BuildAttrsCompat, forms.Widget):
             default_attrs.update(attrs)
         super(MarkItUpWidget, self).__init__(default_attrs)
     
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         if value is None: value = ''
         final_attrs = self.build_attrs_compat(attrs, name=name)
         return mark_safe(u'<div><textarea%s>%s</textarea></div>' % (flatatt(final_attrs),

--- a/wiki/middleware.py
+++ b/wiki/middleware.py
@@ -4,6 +4,7 @@ import importlib
 import threading
 
 from django.conf import settings
+from django.utils.deprecation import MiddlewareMixin
 
 # Take WIKI_REQUEST_CACHE_MIDDLEWARE_CLASS from django settings, if settings is not configured or of
 # WIKI_REQUEST_CACHE_MIDDLEWARE_CLASS setting is not defined then use custom middleware from django-wiki
@@ -30,7 +31,7 @@ else:
     REQUEST_CACHE = _RequestCache()
 
 
-    class RequestCache(object):
+    class RequestCache(MiddlewareMixin):
         @classmethod
         def get_request_cache(cls, name=None):
             """

--- a/wiki/models/urlpath.py
+++ b/wiki/models/urlpath.py
@@ -198,14 +198,15 @@ class URLPath(MPTTModel):
         return reverse('wiki:get', kwargs={'path': self.path})
     
     @classmethod
-    def create_root(cls, site=None, title="Root", **kwargs):
+    def create_root(cls, site=None, title="Root", request=None, **kwargs):
         if not site: site = get_current_site(get_current_request())
         root_nodes = cls.objects.root_nodes().filter(site=site)
         if not root_nodes:
             # (get_or_create does not work for MPTT models??)
             article = Article()
-            article.add_revision(ArticleRevision(title=title, **kwargs),
-                                 save=True)
+            revision = ArticleRevision(title=title, **kwargs)
+            if request: revision.set_from_request(request)
+            article.add_revision(revision, save=True)
             article.save()
             root = cls.objects.create(site=site, article=article)
             article.add_object_relation(root)

--- a/wiki/templates/wiki/article/create_root.html
+++ b/wiki/templates/wiki/article/create_root.html
@@ -4,7 +4,7 @@
 {% block pagetitle %}{% trans "Create root article" %}{% endblock %}
 
 {% block wiki_contents %}
-  
+
   {% addtoblock "js" %}
   {% for js in editor.Media.js %}
   <script type="text/javascript" src="{{ STATIC_URL }}{{ js }}"></script>
@@ -23,14 +23,17 @@
   <p class="lead">
     {% trans "You have django-wiki installed... but there are no articles. So it's time to create the first one, the root article. In the beginning, it will only be editable by administrators, but you can define permissions after." %}
   </p>
-  
+
   <h2 class="page-header">{% trans "Root article" %}</h2>
-  
+
   <form method="POST" class="form-horizontal">
-    {% wiki_form create_form %}
-    <div class="form-actions">
+    {% wiki_form form %}
+    <div class="form-group form-actions">
+      <div class="col-lg-2"></div>
+      <div class="col-lg-10">
         <input type="submit" name="save_changes" value="{% trans "Create root" %} &raquo;" class="btn btn-primary btn-large" />
-    </div>  
+      </div>
+    </div>
   </form>
 
 {% endblock %}

--- a/wiki/urls.py
+++ b/wiki/urls.py
@@ -9,7 +9,7 @@ from wiki.views import accounts, article
 
 urlpatterns = [
     url(r'^$', article.ArticleView.as_view(), name='root', kwargs={'path': ''}),
-    url(r'^create-root/$', article.root_create, name='root_create'),
+    url(r'^create-root/$', article.CreateRootView.as_view(), name='root_create'),
     url(r'^_revision/diff/(?P<revision_id>\d+)/$', article.diff, name='diff'),
 ]
 
@@ -68,6 +68,8 @@ urlpatterns += [
     url(r'^(?P<path>.+/|)_plugin/(?P<slug>\w+)/$', article.Plugin.as_view(), name='plugin'),
     url(r'^(?P<path>.+/|)$', article.ArticleView.as_view(), name='get'),
 ]
+
+app_name = 'wiki'
 
 def get_pattern(app_name="wiki"):
     """Every url resolution takes place as "wiki:view_name".


### PR DESCRIPTION
**Description**
This PR is part of splitting this previous one https://github.com/edx/django-wiki/pull/59/files into three steps:
- Update python to make it compatible with Django 2.2 and tests.
- Include some tests from upstream.
- Add compliance with OEP-18.

In this PR:
Create root as a class-based view. Cherry picked 10a44575435c6a3641c5abd6957d61341d8d42ae. 
Other adjustments to be compatible with Django 2.2 and to make code compatible with tests coming in a follow-up PR. Tests come from a compatible version of upstream.

**Reviewers**
- [ ] @awais786 
- [ ] @morenol