### PR TITLE
Upgrade markdown version and fix tests

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -21,10 +21,8 @@ django==2.2.17
     #   django-classy-tags
     #   django-mptt
     #   django-sekizai
-markdown==2.6.11
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.in
+markdown==3.3.3
+    # via -r requirements/base.in
 packaging==20.8
     # via bleach
 pyparsing==2.4.7

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -12,6 +12,3 @@
 
 # Use latest Django LTS version
 Django<2.3.0
-
-# Use version 2.6 to avoid markdown errors
-Markdown<2.7

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -30,10 +30,8 @@ django-sekizai==2.0.0
     #   django-sekizai
 iniconfig==1.1.1
     # via pytest
-markdown==2.6.11
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.txt
+markdown==3.3.3
+    # via -r requirements/base.txt
 packaging==20.8
     # via
     #   -r requirements/base.txt

--- a/wiki/plugins/links/mdx/djangowikilinks.py
+++ b/wiki/plugins/links/mdx/djangowikilinks.py
@@ -40,16 +40,16 @@ class WikiPathExtension(markdown.Extension):
             'live_lookups': [True, 'If the plugin should try and match links to real articles'],
             'default_level': [2, 'The level that most articles are created at. Relative links will tend to start at that level.']
         }
-        
+
         # Override defaults with user settings
         super().__init__(**kwargs)
-        
+
     def extendMarkdown(self, md, md_globals):
         self.md = md
-        
+
         # append to end of inline patterns
         WIKI_RE =  r'\[(?P<linkTitle>[^\]]+?)\]\(wiki:(?P<wikiTitle>[a-zA-Z\d\./_-]*)\)'
-        wikiPathPattern = WikiPath(WIKI_RE, self.config, markdown_instance=md)
+        wikiPathPattern = WikiPath(WIKI_RE, self.config, md=md)
         wikiPathPattern.md = md
         md.inlinePatterns.add('djangowikipath', wikiPathPattern, "<reference")
 
@@ -58,7 +58,7 @@ class WikiPath(markdown.inlinepatterns.Pattern):
     def __init__(self, pattern, config, **kwargs):
         markdown.inlinepatterns.Pattern.__init__(self, pattern, **kwargs)
         self.config = config
-    
+
     def handleMatch(self, m) :
         from wiki import models
         article_title = m.group('wikiTitle')
@@ -66,7 +66,7 @@ class WikiPath(markdown.inlinepatterns.Pattern):
         if article_title.startswith("/"):
             absolute = True
         article_title = article_title.strip("/")
-        
+
         # Use this to calculate some kind of meaningful path
         # from the link, regardless of whether or not something can be
         # looked up
@@ -75,7 +75,7 @@ class WikiPath(markdown.inlinepatterns.Pattern):
         if absolute:
             base_path = self.config['base_url'][0]
             path_from_link = os_path.join(base_path, article_title)
-            
+
             urlpath = None
             path = path_from_link
             if self.config['live_lookups'][0]:
@@ -91,23 +91,23 @@ class WikiPath(markdown.inlinepatterns.Pattern):
             # one more component would make a path of length self.config['default_level']
             starting_level = max(0, self.config['default_level'][0] - 1 )
             starting_path = "/".join(source_components[ : starting_level ])
-            
+
             path_from_link = os_path.join(starting_path, article_title)
-            
+
             lookup = models.URLPath.objects.none()
             if self.config['live_lookups'][0]:
                 if urlpath.parent:
                     lookup = urlpath.parent.get_descendants().filter(slug=article_title)
                 else:
                     lookup = urlpath.get_descendants().filter(slug=article_title)
-            
+
             if lookup.count() > 0:
                 urlpath = lookup[0]
                 path = urlpath.get_absolute_url()
             else:
                 urlpath = None
                 path = self.config['base_url'][0] + path_from_link
-            
+
         label = m.group('linkTitle')
         a = etree.Element('a')
         a.set('href', path)
@@ -116,9 +116,9 @@ class WikiPath(markdown.inlinepatterns.Pattern):
         else:
             a.set('class', self.config['html_class'][0])
         a.text = label
-            
+
         return a
-        
+
     def _getMeta(self):
         """ Return meta data or config data. """
         base_url = self.config['base_url'][0]

--- a/wiki/plugins/links/mdx/urlize.py
+++ b/wiki/plugins/links/mdx/urlize.py
@@ -58,8 +58,8 @@ URLIZE_RE = (
 class UrlizePattern(markdown.inlinepatterns.Pattern):
 
     def __init__(self, pattern, markdown_instance=None):
-        markdown.inlinepatterns.Pattern.__init__(self, pattern, markdown_instance=markdown_instance)
-        self.compiled_re = re.compile("^(.*?)%s(.*?)$" % pattern, 
+        markdown.inlinepatterns.Pattern.__init__(self, pattern, md=markdown_instance)
+        self.compiled_re = re.compile("^(.*?)%s(.*?)$" % pattern,
                                       re.DOTALL | re.UNICODE | re.IGNORECASE)
 
     """ Return a link Element given an autolink (`http://example/com`). """
@@ -68,18 +68,18 @@ class UrlizePattern(markdown.inlinepatterns.Pattern):
 
         if url.startswith('<'):
             url = url[1:-1]
-            
+
         text = url
-        
+
         if not url.split('://')[0] in ('http','https','ftp'):
             if '@' in url and not '/' in url:
                 url = 'mailto:' + url
             else:
                 url = 'http://' + url
-        
+
         icon = markdown.util.etree.Element("span")
         icon.set('class', 'icon-globe')
-        
+
         span_text = markdown.util.etree.Element("span")
         span_text.text = markdown.util.AtomicString(" " + text)
         el = markdown.util.etree.Element("a")


### PR DESCRIPTION
This PR is being made in order to fix the errors coming up in https://github.com/edx/edx-platform/pull/26072. 
Removed markdown constraint to update its version to the latest and fixed the failing tests.
This PR needs the base PR https://github.com/edx/django-wiki/pull/65 so that the latest version of markdown is fetched which we need in edx-platform.