### PR TITLE
fix: upgrade bleach version to 5.0.0

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,7 +1,7 @@
 # Core requirements for using this package
 -c constraints.txt
 
-bleach				# Use for sanitizing HTML content in wiki articles
+bleach[css]			# Use for sanitizing HTML content in wiki articles
 django
 django-mptt
 django-sekizai

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,10 +4,8 @@
 #
 #    make upgrade
 #
-bleach==4.1.0
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.in
+bleach[css]==5.0.0
+    # via -r requirements/base.in
 django==2.2.28
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
@@ -28,10 +26,6 @@ importlib-metadata==4.11.3
     # via markdown
 markdown==3.3.6
     # via -r requirements/base.in
-packaging==21.3
-    # via bleach
-pyparsing==3.0.8
-    # via packaging
 pytz==2022.1
     # via django
 six==1.16.0
@@ -40,7 +34,11 @@ sorl-thumbnail==12.8.0
     # via -r requirements/base.in
 sqlparse==0.4.2
     # via django
-webencodings==0.5.1
+tinycss2==1.1.1
     # via bleach
+webencodings==0.5.1
+    # via
+    #   bleach
+    #   tinycss2
 zipp==3.8.0
     # via importlib-metadata

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -14,8 +14,3 @@
 -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
 
 Django<2.3.0
-
-# bleach==5.0.0 contains breaking changes related to clean() function used to sanitize css
-# Code needs to be refactored to fix the test failures with the new version.
-# Will be done in https://openedx.atlassian.net/browse/BOM-3374
-bleach<5.0.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,10 +6,8 @@
 #
 attrs==21.4.0
     # via pytest
-bleach==4.1.0
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.txt
+bleach[css]==5.0.0
+    # via -r requirements/base.txt
 coverage[toml]==6.3.2
     # via pytest-cov
     # via
@@ -40,18 +38,13 @@ iniconfig==1.1.1
 markdown==3.3.6
     # via -r requirements/base.txt
 packaging==21.3
-    # via
-    #   -r requirements/base.txt
-    #   bleach
-    #   pytest
+    # via pytest
 pluggy==1.0.0
     # via pytest
 py==1.11.0
     # via pytest
 pyparsing==3.0.8
-    # via
-    #   -r requirements/base.txt
-    #   packaging
+    # via packaging
 pytest==7.1.1
     # via
     #   -r requirements/test.in
@@ -75,12 +68,19 @@ sqlparse==0.4.2
     # via
     #   -r requirements/base.txt
     #   django
+tinycss2==1.1.1
+    # via
+    #   -r requirements/base.txt
+    #   bleach
 tomli==2.0.1
-    # via pytest
+    # via
+    #   coverage
+    #   pytest
 webencodings==0.5.1
     # via
     #   -r requirements/base.txt
     #   bleach
+    #   tinycss2
 zipp==3.8.0
     # via
     #   -r requirements/base.txt

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ package_data = {
 
 setup(
     name="django-wiki",
-    version="1.0.2",
+    version="1.0.3",
     author="Benjamin Bach",
     author_email="benjamin@overtag.dk",
     description="A wiki system written for the Django framework.",

--- a/wiki/core/__init__.py
+++ b/wiki/core/__init__.py
@@ -1,5 +1,6 @@
 import bleach
 import markdown
+from bleach.css_sanitizer import CSSSanitizer
 from wiki.conf import settings
 
 
@@ -12,11 +13,14 @@ class ArticleMarkdown(markdown.Markdown):
     def convert(self, text, *args, **kwargs):
         html = super().convert(text, *args, **kwargs)
         if settings.MARKDOWN_SANITIZE_HTML:
+            css_sanitizer = CSSSanitizer()
+            if settings.MARKDOWN_HTML_STYLES:
+                css_sanitizer = CSSSanitizer(allowed_css_properties=settings.MARKDOWN_HTML_STYLES)
             html = bleach.clean(
                 html,
                 tags=settings.MARKDOWN_HTML_WHITELIST,
                 attributes=settings.MARKDOWN_HTML_ATTRIBUTES,
-                styles=settings.MARKDOWN_HTML_STYLES,
+                css_sanitizer=css_sanitizer,
                 strip=True,
             )
         return html


### PR DESCRIPTION
### Description
- `bleach==5.0.0` introduced a new function to sanitize css attributes instead of using the default `style` parameter. For details check the thread https://github.com/mozilla/bleach/issues/633.