### PR TITLE
build: add django 40 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         python-version: ['3.8']
-        toxenv: [django32]
+        toxenv: [django32, django40]
     steps:
     - uses: actions/checkout@v1
     - name: setup python

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ package_data = {
 
 setup(
     name="django-wiki",
-    version="1.0.3",
+    version="1.1.0",
     author="Benjamin Bach",
     author_email="benjamin@overtag.dk",
     description="A wiki system written for the Django framework.",
@@ -80,6 +80,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Framework :: Django',
         'Framework :: Django :: 3.2',
+        'Framework :: Django :: 4.0',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development',
         'Topic :: Software Development :: Libraries :: Application Frameworks',

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 [tox]
-envlist = py38-django{32}
+envlist = py38-django{32,40}
 
 [testenv]
 deps =
     django32: -r requirements/django.txt
+    django40: django>4.0,<4.1
 	-r{toxinidir}/requirements/test.txt
 changedir={toxinidir}/testproject/
 commands =


### PR DESCRIPTION
### Description
- Added `Django 4.0` tests support and bumped the version to `1.1.0` to bump in `edx-platform`.