### PR TITLE
Fix package name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ package_data = {
 }
 
 setup(
-    name="django-wiki",
+    name="openedx-django-wiki",
     version="1.1.3",
     author="Benjamin Bach",
     author_email="benjamin@overtag.dk",

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ package_data = {
 
 setup(
     name="openedx-django-wiki",
-    version="1.1.3",
+    version="1.1.4",
     author="Benjamin Bach",
     author_email="benjamin@overtag.dk",
     long_description_content_type='text/markdown',


### PR DESCRIPTION
django-wiki name is already taken on PyPI, hence changing the name by prefixing openedx.