### PR TITLE
chore: removing configs. These are deprecated.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ package_data = {
 
 setup(
     name="openedx-django-wiki",
-    version="2.0.0",
+    version="2.0.1",
     author="Benjamin Bach",
     author_email="benjamin@overtag.dk",
     long_description_content_type='text/markdown',

--- a/testproject/testproject/settings.py
+++ b/testproject/testproject/settings.py
@@ -105,9 +105,9 @@ INSTALLED_APPS = [
     'wiki',
     'wiki.plugins.help',
     'wiki.plugins.links',
-    'wiki.plugins.images',
-    'wiki.plugins.attachments',
-    'wiki.plugins.notifications',
+    'wiki.apps.ImagesConfig',
+    'wiki.apps.AttachmentsConfig',
+    'wiki.apps.NotifcationsConfig',
     'mptt',
 ]
 

--- a/wiki/plugins/attachments/__init__.py
+++ b/wiki/plugins/attachments/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = 'wiki.apps.AttachmentsConfig'

--- a/wiki/plugins/images/__init__.py
+++ b/wiki/plugins/images/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = 'wiki.apps.ImagesConfig'

--- a/wiki/plugins/images/migrations/0001_initial.py
+++ b/wiki/plugins/images/migrations/0001_initial.py
@@ -25,7 +25,7 @@ class Migration(migrations.Migration):
             name='ImageRevision',
             fields=[
                 ('revisionpluginrevision_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='wiki.RevisionPluginRevision', on_delete=models.CASCADE)),
-                ('image', models.ImageField(upload_to=wiki.plugins.images.models.upload_path, width_field=b'width', height_field=b'height', max_length=2000, blank=True, null=True)),
+                ('image', models.ImageField(upload_to=wiki.plugins.images.models.upload_path, width_field='width', height_field='height', max_length=2000, blank=True, null=True)),
                 ('width', models.SmallIntegerField(null=True, blank=True)),
                 ('height', models.SmallIntegerField(null=True, blank=True)),
             ],

--- a/wiki/plugins/notifications/__init__.py
+++ b/wiki/plugins/notifications/__init__.py
@@ -1,4 +1,2 @@
-default_app_config = 'wiki.apps.NotifcationsConfig'
-
 # Key for django_notify
 ARTICLE_EDIT = "article_edit"


### PR DESCRIPTION
Removed `b` from migrations. otherwise it generates new migrations with django32.
Removed configs. For [details](https://django.readthedocs.io/en/stable/releases/3.2.html#what-s-new-in-django-3-2) checkout django32 notes. Doing this now otherwise django42 prs fails on running migrations and require these changes.

TODO: Verify this hash on sandbox.