### PR TITLE
refactor: update markdown to 3.8 and adapt extension code for compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## [3.1.1] - 2025-05-16
+
+### Changed
+- Bumped `markdown` dependency to 3.8
+- Refactored custom Markdown extensions to remove `md_globals`, use `register()`, and adjust processor priorities for compatibility with markdown >=3.4.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -23,10 +23,8 @@ django-mptt==0.17.0
     # via -r requirements/base.in
 django-sekizai==4.1.0
     # via -r requirements/base.in
-markdown==3.3.7
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.in
+markdown==3.8
+    # via -r requirements/base.in
 sorl-thumbnail==12.11.0
     # via -r requirements/base.in
 sqlparse==0.5.3

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -11,8 +11,5 @@
 # Use Django LTS version pinned in common constraints
 -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
 
-# markdown==3.4.0 contains refactoring which are breaking the package itself
-markdown<3.4.0
-
 # For python greater than or equal to 3.9 backports.zoneinfo causing failures
 backports.zoneinfo; python_version<'3.9'

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -32,10 +32,8 @@ django-sekizai==4.1.0
     # via -r requirements/base.txt
 iniconfig==2.1.0
     # via pytest
-markdown==3.3.7
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.txt
+markdown==3.8
+    # via -r requirements/base.txt
 packaging==25.0
     # via pytest
 pluggy==1.5.0

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ package_data = {
 
 setup(
     name="openedx-django-wiki",
-    version="3.1.0",
+    version="3.1.1",
     author="Benjamin Bach",
     author_email="benjamin@overtag.dk",
     long_description_content_type='text/markdown',

--- a/wiki/core/extensions.py
+++ b/wiki/core/extensions.py
@@ -7,5 +7,5 @@ class AnchorTagExtension(Extension):
     """
     Custom extension to register anchor tag processor with Markdown.
     """
-    def extendMarkdown(self, md, md_globals):
-        md.treeprocessors.add('AnchorTagProcessor', AnchorTagProcessor(md), '>inline')
+    def extendMarkdown(self, md):
+        md.treeprocessors.register(AnchorTagProcessor(md), 'AnchorTagProcessor', 20)

--- a/wiki/plugins/attachments/markdown_extensions.py
+++ b/wiki/plugins/attachments/markdown_extensions.py
@@ -12,9 +12,9 @@ ATTACHMENT_RE = re.compile(r'.*(\[attachment\:(?P<id>\d+)\]).*', re.IGNORECASE)
 class AttachmentExtension(markdown.Extension):
     """ Abbreviation Extension for Python-Markdown. """
 
-    def extendMarkdown(self, md, md_globals):
+    def extendMarkdown(self, md):
         """ Insert AbbrPreprocessor before ReferencePreprocessor. """
-        md.preprocessors.add('dw-attachments', AttachmentPreprocessor(md), '>html_block')
+        md.preprocessors.register(AttachmentPreprocessor(md), 'dw-attachments', 20)
 
 class AttachmentPreprocessor(markdown.preprocessors.Preprocessor):
     """django-wiki attachment preprocessor - parse text for [attachment:id] references. """

--- a/wiki/plugins/images/markdown_extensions.py
+++ b/wiki/plugins/images/markdown_extensions.py
@@ -13,9 +13,9 @@ from wiki.plugins.images import models
 class ImageExtension(markdown.Extension):
     """ Images plugin markdown extension for django-wiki. """
 
-    def extendMarkdown(self, md, md_globals):
+    def extendMarkdown(self, md):
         """ Insert ImagePreprocessor before ReferencePreprocessor. """
-        md.preprocessors.add('dw-images', ImagePreprocessor(md), '>html_block')
+        md.preprocessors.register(ImagePreprocessor(md), 'dw-images', 20)
 
 class ImagePreprocessor(markdown.preprocessors.Preprocessor):
     """django-wiki image preprocessor - parse text for [image:id align:left|right|center] references. """

--- a/wiki/plugins/links/mdx/djangowikilinks.py
+++ b/wiki/plugins/links/mdx/djangowikilinks.py
@@ -44,14 +44,14 @@ class WikiPathExtension(markdown.Extension):
         # Override defaults with user settings
         super().__init__(**kwargs)
 
-    def extendMarkdown(self, md, md_globals):
+    def extendMarkdown(self, md):
         self.md = md
 
         # append to end of inline patterns
         WIKI_RE =  r'\[(?P<linkTitle>[^\]]+?)\]\(wiki:(?P<wikiTitle>[a-zA-Z\d\./_-]*)\)'
         wikiPathPattern = WikiPath(WIKI_RE, self.config, md=md)
         wikiPathPattern.md = md
-        md.inlinePatterns.add('djangowikipath', wikiPathPattern, "<reference")
+        md.inlinePatterns.register(wikiPathPattern, 'djangowikipath', 170)
 
 
 class WikiPath(markdown.inlinepatterns.Pattern):

--- a/wiki/plugins/links/mdx/urlize.py
+++ b/wiki/plugins/links/mdx/urlize.py
@@ -77,12 +77,12 @@ class UrlizePattern(markdown.inlinepatterns.Pattern):
             else:
                 url = 'http://' + url
 
-        icon = markdown.util.etree.Element("span")
+        icon = xml.etree.ElementTree.Element("span")
         icon.set('class', 'icon-globe')
 
-        span_text = markdown.util.etree.Element("span")
+        span_text = xml.etree.ElementTree.Element("span")
         span_text.text = markdown.util.AtomicString(" " + text)
-        el = markdown.util.etree.Element("a")
+        el = xml.etree.ElementTree.Element("a")
         el.set('href', url)
         el.set('target', '_blank')
         el.extend([icon, span_text])
@@ -92,7 +92,7 @@ class UrlizePattern(markdown.inlinepatterns.Pattern):
 class UrlizeExtension(markdown.Extension):
     """ Urlize Extension for Python-Markdown. """
 
-    def extendMarkdown(self, md, md_globals):
+    def extendMarkdown(self, md):
         """ Replace autolink with UrlizePattern """
         md.inlinePatterns['autolink'] = UrlizePattern(URLIZE_RE, md)
 


### PR DESCRIPTION
### Purpose

This PR resolves a compatibility issue with the `markdown` dependency, which surfaced while addressing [edx-platform issue #35271](https://github.com/openedx/edx-platform/issues/35271).

### Background

The `edx-platform` currently pins `markdown` to `<3.4.0`. When attempting to lift that constraint and upgrade `markdown` to the latest version (`3.8`), tests in this repository failed due to breaking changes introduced in `markdown>=3.4.0`.

As outlined in the [markdown 3.4 release notes](https://github.com/Python-Markdown/markdown/blob/3.4/docs/change_log/release-3.4.md), key breaking changes include:

* Removal of the `md_globals` parameter from `Extension.extendMarkdown()`
* Replacing the `.add()` method with `.register()` in processor registration
* Changing the argument order and priority system in processor registration
* Refactoring of `markdown.util.etree` to use the standard library's `xml.etree.ElementTree`

**Below is a sample illustration of changes from the 3.4 release notes**
<image src="https://github.com/user-attachments/assets/15ec4d45-89df-4000-a7eb-0d3c77a56480" alt="ss" width="500px" height="350px" />

### Changes Made

* Upgraded `markdown` to version `3.8` in `base.in` and `test.in`
* Refactored custom Markdown extensions to:

  * Remove deprecated `md_globals` usage
  * Replace `add()` with `register()` for preprocessor and treeprocessor registration
  * Use integer-based priority values instead of deprecated string-based values (e.g., `'>inline'`, `'>html_block'`)
* Ensured compatibility with the updated Markdown processing API
* Verified all tests pass after the upgrade

### Follow-Up

Once this PR is merged, it will unblock and help resolve:
[edx-platform issue #35271](https://github.com/openedx/edx-platform/issues/35271)

### References
- https://github.com/Python-Markdown/markdown/blob/3.4/docs/change_log/release-3.4.md
- https://github.com/Python-Markdown/markdown/tree/master/markdown