### PR TITLE
doc: Fix PII model annotations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ package_data = {
 
 setup(
     name="openedx-django-wiki",
-    version="3.1.1",
+    version="3.1.2",
     author="Benjamin Bach",
     author_email="benjamin@overtag.dk",
     long_description_content_type='text/markdown',

--- a/wiki/models/article.py
+++ b/wiki/models/article.py
@@ -275,7 +275,7 @@ class ArticleRevision(BaseRevisionMixin, models.Model):
     copy, do NEVER create m2m relationships.
 
     .. pii: This model stores the IP addresses of users who have edited the article
-    .. pii_types: choice_ip
+    .. pii_types: ip
     .. pii_retirement: local_api
     """
 

--- a/wiki/models/pluginbase.py
+++ b/wiki/models/pluginbase.py
@@ -201,7 +201,7 @@ class RevisionPluginRevision(BaseRevisionMixin, models.Model):
     (this class is very much copied from wiki.models.article.ArticleRevision)
 
     .. pii: This model stores the IP addresses of users who have edited the object
-    .. pii_types: choice_ip
+    .. pii_types: ip
     .. pii_retirement: local_api
     """
 


### PR DESCRIPTION
These used an old form of the pii_types key and needed to be updated.